### PR TITLE
Do not use string imports deprecation warning

### DIFF
--- a/googlecalendar/urls.py
+++ b/googlecalendar/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import patterns, url
 
-urlpatterns = patterns('googlecalendar.views',
-    url(r'^(?P<slug>[a-z0-9_-]+)/(?P<event>[a-z0-9_-]+)$', 'googlecalendar_event', name='googlecalendar_event'),
-    url(r'^(?P<slug>[a-z0-9_-]+)/$', 'googlecalendar', name='googlecalendar_detail'),
-    url(r'^$', 'googlecalendar_list', name='googlecalendar'),
-)
+import googlecalendar.views as gc_views
 
+urlpatterns = [
+    url(r'^(?P<slug>[a-z0-9_-]+)/(?P<event>[a-z0-9_-]+)$', gc_views.googlecalendar_event, name='googlecalendar_event'),
+    url(r'^(?P<slug>[a-z0-9_-]+)/$', gc_views.googlecalendar, name='googlecalendar_detail'),
+    url(r'^$', gc_views.googlecalendar_list, name='googlecalendar'),
+]


### PR DESCRIPTION
This is the PR for the `omni-digital/django-googlecalendar`, which resolved all remaining deprecation warnings from this module. Once this is merged I'll bump the version number and update the requirements file in `ght`.