### PR TITLE
Change feincms import due to deprecation

### DIFF
--- a/googlecalendar/models.py
+++ b/googlecalendar/models.py
@@ -12,7 +12,7 @@ from django.contrib.sites.models import Site
 
 
 from feincms.models import Base
-from feincms.content.medialibrary.models import MediaFileContent
+from feincms.module.medialibrary.models import MediaFileContent
 from feincms.content.richtext.models import RichTextContent
 
 import mptt


### PR DESCRIPTION
For versions of `feincms>=1.12.0` the following deprecation warning is raised:
```
/home/enric/.pyenv/versions/2.7.15/envs/tghn/src/django-googlecalendar/googlecalendar/models.py:15: DeprecationWarning: Import MediaFileContent from feincms.module.medialibrary.contents.
  from feincms.content.medialibrary.models import MediaFileContent
```
This PR addresses the deprecation warning.