### PR TITLE
Task/deprecate uni form

### DIFF
--- a/googlecalendar/__init__.py
+++ b/googlecalendar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (3, 1, 3, 'dev')
+__version__ = (3, 1, 4, 'dev')
 
 
 def get_version():

--- a/googlecalendar/templates/googlecalendar/calendar_detail.html
+++ b/googlecalendar/templates/googlecalendar/calendar_detail.html
@@ -1,7 +1,7 @@
 {% extends "googlecalendar/base.html" %}
 
-{% load i18n pagination_tags googlecalendartags %}
-{% load uni_form_tags %}
+{% crispy_forms_tags load i18n pagination_tags googlecalendartags %}
+
 {% block extrascript %}
     {{ block.super }}
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.7/jquery-ui.min.js"></script>
@@ -23,7 +23,7 @@
     {% embedcalendar object %}
     {% if event_form %}
         <form action="" method="post" >
-            {{ event_form|as_uni_form }}
+            {{ event_form|crispy }}
             <input type="submit" value="{%  trans 'Submit' %}">
         </form>
     {% endif %}

--- a/googlecalendar/templates/googlecalendar/calendar_list.html
+++ b/googlecalendar/templates/googlecalendar/calendar_list.html
@@ -1,8 +1,7 @@
 {% extends "googlecalendar/base.html" %}
 
-{% load i18n %}
+{% load crispy_forms_tags i18n %}
 {% load googlecalendartags %}
-{% load uni_form_tags %}
 
 {% block extrascript %}
     {{ block.super }}
@@ -26,7 +25,7 @@
     {% embedcalendar %}
     {% if event_form %}
         <form action="" method="post" >
-            {{ event_form|as_uni_form }}
+            {{ event_form|crispy }}
             <input type="submit" value="{%  trans 'Submit' %}">
         </form>
     {% endif %}


### PR DESCRIPTION
# Deprecate `uni-form` in favour of `crispy-forms`

Starting with v1.2.0 of `crispy-forms`, the old tags compatible with `uni-form` were deprecated. This fixes that by using the new tags for crispy.