### PR TITLE
render_to_response replaced by render

### DIFF
--- a/googlecalendar/__init__.py
+++ b/googlecalendar/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (3, 1, 4, 'dev')
+__version__ = (3, 1, 5, 'dev')
 
 
 def get_version():

--- a/googlecalendar/models.py
+++ b/googlecalendar/models.py
@@ -150,7 +150,7 @@ class Calendar(models.Model):
     @models.permalink
     def get_absolute_url(self):
         return ('googlecalendar_detail', (), {
-                'calendar': self.slug,
+                'slug': self.slug,
                 })
 
     def save(self):

--- a/googlecalendar/views.py
+++ b/googlecalendar/views.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.core.mail import mail_admins
-from django.shortcuts import get_object_or_404, render_to_response
+from django.shortcuts import get_object_or_404, render_to_response, render
 from django.template import RequestContext
 from django.utils.translation import ugettext_lazy as _
 
@@ -12,7 +12,7 @@ from googlecalendar.models import Calendar, Event
 
 
 def googlecalendar_list(request, extra_context=None, template_name='googlecalendar/calendar_list.html'):
-    context = RequestContext(request)
+    context = {'request': request}
     if extra_context is not None:
         context.update(extra_context)
 
@@ -41,10 +41,11 @@ def googlecalendar_list(request, extra_context=None, template_name='googlecalend
                 return HttpResponseRedirect(reverse('googlecalendar'))
 
     context.update({'object_list': active_calendars, 'event_form': event_form})
-    return render_to_response(template_name, context)
+    return render(request, template_name, context=context)
+
 
 def googlecalendar(request, slug, extra_context=None, template_name='googlecalendar/calendar_detail.html'):
-    context = RequestContext(request)
+    context = {'request': request}
     if extra_context is not None:
         context.update(extra_context)
 
@@ -62,7 +63,8 @@ def googlecalendar(request, slug, extra_context=None, template_name='googlecalen
                 messages.add_message(request, messages.INFO, _('New event was successfully saved'))
 
     context.update({'object': calendar, 'event_form' : event_form})
-    return render_to_response(template_name, context)
+    return render(request, template_name, context=context)
+
 
 def googlecalendar_event(request, slug, event, extra_context=None, template_name='googlecalendar/event_detail.html'):
     context = RequestContext(request)

--- a/googlecalendar/views.py
+++ b/googlecalendar/views.py
@@ -67,9 +67,9 @@ def googlecalendar(request, slug, extra_context=None, template_name='googlecalen
 
 
 def googlecalendar_event(request, slug, event, extra_context=None, template_name='googlecalendar/event_detail.html'):
-    context = RequestContext(request)
+    context = {'request': request}
     if extra_context is not None:
         context.update(extra_context)
 
     context.update({'object': get_object_or_404(Event.objects.active(), slug=event, calendar__slug=slug)})
-    return render_to_response(template_name, context)
+    return render(request, template_name, context=context)


### PR DESCRIPTION
# `render_to_response` replaced by `render` to avoid errors

Passing a `RequestContext` object to `render_to_response` was deprecated with Django 1.11, so this PR replaces it with `render` to avoid the error entirely.